### PR TITLE
Some enhancements to dollar-string highlighting.

### DIFF
--- a/doc/pgsql.txt
+++ b/doc/pgsql.txt
@@ -43,12 +43,14 @@ Identifiers starting with an underscore are highlighted as
 variables. It is recommended to adopt the convention of prefixing
 function parameters and local variables with `_`.
 
-Code between `$pgsql$` or `$$` pairs is interpreted as PL/pgSQL and
-highlighted accordingly. To use any other language, such as PL/Perl,
-PL/Python, PL/R, and so on, see |pgsql-customization|.
+Code between `$pgsql$`, `$BODY$`, or `$$` pairs is interpreted as
+PL/pgSQL and highlighted accordingly. To use any other language,
+such as PL/Perl, PL/Python, PL/R, and so on, see
+|pgsql-customization|.  Also see |g:pgsql_dollars_as_text|.
 
-Text enclosed between `$HERE$` pairs is highlighted as
-a (multi-line) string.
+Text enclosed between `$anyword$` pairs is highlighted as a
+(multi-line) string.  `anyword` can be any sequence of word
+characters.
 
 ====================================================================
 Section 2: Customization                       *pgsql-customization*
@@ -81,6 +83,10 @@ To recognize `\'` as an escape sequences in all strings, set
 |g:pgsql_backslash_quote| to 1. By default, `\'` is treated as an
 escape sequence only in “escape” strings constants, i.e., strings
 enclosed in `E''`.
+
+By default, text quoted with `$$` will be highlighted as PL/pgSQL.
+If you prefer these to be highlighted as SQL strings, you may set
+|g:pgsql_dollars_as_text| to 1.
 
 ====================================================================
 Section 3: Autocompletion                     *pgsql-autocompletion*

--- a/src/pgsql.sql
+++ b/src/pgsql.sql
@@ -207,12 +207,15 @@ syn match sqlNumber "\<\d*\.\=[0-9_]\>"
 " Strings
 if get(g:, 'pgsql_backslash_quote', 0)
   syn region sqlString start=+E\?'+ skip=+\\\\\|\\'\|''+ end=+'+ contains=@Spell
-  syn region sqlString start=+\$HERE\$+ end=+\$HERE\$+ contains=@Spell
 else
   syn region sqlString start=+E'+ skip=+\\\\\|\\'\|''+ end=+'+ contains=@Spell
   syn region sqlString start=+'+ skip=+''+ end=+'+ contains=@Spell
-  syn region sqlString start=+\$HERE\$+ end=+\$HERE\$+ contains=@Spell
 endif
+syn region sqlString start='\$\z(\w\+\)\$' end='\$\z1\$' contains=@Spell
+if get(g:, 'pgsql_dollars_as_text', 0)
+    syn region sqlString start=+\$\$+ end=+\$\$+ contains=@Spell
+endif
+
 " Escape String Constants
 " Identifiers
 syn region sqlIdentifier start=+\%(U&\)\?"+ end=+"+
@@ -283,7 +286,10 @@ syn match sqlPlpgsqlVariable "\$\d\+" contained
 syn match sqlPlpgsqlVariable ".\zs@[A-z0-9_]\+" contained
 
 syn region plpgsql matchgroup=sqlString start=+\$pgsql\$+ end=+\$pgsql\$+ keepend contains=ALL
-syn region plpgsql matchgroup=sqlString start=+\$\$+ end=+\$\$+ keepend contains=ALL
+syn region plpgsql matchgroup=sqlString start=+\$BODY\$+ end=+\$BODY\$+ keepend contains=ALL
+if ! get(g:, 'pgsql_dollars_as_text', 0)
+  syn region plpgsql matchgroup=sqlString start=+\$\$+ end=+\$\$+ keepend contains=ALL
+endif
 
 " PL/<any other language>
 fun! s:add_syntax(s)


### PR DESCRIPTION
Replace `$HERE$` with `$anyword$`, where anyword consists of a string of 1 or more word characters.
Add `$BODY$` as a synonym for `$pgsql$`. (These supercede `$anyword$`.)
Add a setting, `g:pgsql_dollars_as_text`, which, when set to '1', will make `$$` strings be highlighted as plain text instead of PL/pgSQL code.