### PR TITLE
make Prettier, update to CommonMark-spec Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,31 +5,32 @@
 This plugin provides syntax highlighting and auto-completion support for
 PostgreSQL version 9.6 or above and for some of its extensions, including:
 
-- PL/pgSQL;
-- [PostGIS](http://postgis.net) (including PostGIS Topology);
-- [pgRouting](http://pgrouting.org);
-- [pgTap](http://pgtap.org).
+-   PL/pgSQL;
+-   [PostGIS](http://postgis.net) (including PostGIS Topology);
+-   [pgRouting](http://pgrouting.org);
+-   [pgTap](http://pgtap.org).
 
 Besides, syntax highlighting for any language may be activated inside functions
 (see below).
-
 
 # Installation
 
 If your Vim supports packages (`echo has('packages')` prints `1`), I strongly
 recommend that you use them. Just clone this repo inside `pack/*/start`, e.g.,
 
-    mkdir -p ~/.vim/pack/plugins/start
-    git clone https://github.com/lifepillar/pgsql.vim.git ~/.vim/pack/plugins/start/pgsql
-    
+```bash
+mkdir -p ~/.vim/pack/plugins/start
+git clone https://github.com/lifepillar/pgsql.vim.git ~/.vim/pack/plugins/start/pgsql
+```
 
 Otherwise, if you don't have a preferred installation method, I recommend
 installing [Pathogen](https://github.com/tpope/vim-pathogen), and then simply
 copy and paste:
 
-    cd ~/.vim/bundle
-    git clone https://github.com/lifepillar/pgsql.vim.git
-
+```bash
+cd ~/.vim/bundle
+git clone https://github.com/lifepillar/pgsql.vim.git
+```
 
 # Usage
 
@@ -39,15 +40,21 @@ Files with a `.pgsql` suffix are highlighted out of the box. If you want to
 highlight `.sql` files using this plugin by default, add this to your `.vimrc`
 (see `:h ft_sql.txt`):
 
-    let g:sql_type_default = 'pgsql'
+```vim
+let g:sql_type_default = 'pgsql'
+```
 
 Alternatively, after loading a `.sql` file use this command:
 
-    :SQLSetType pgsql.vim
+```vim
+:SQLSetType pgsql.vim
+```
 
 To set the file type in new buffers use:
 
-    :let b:sql_type_override='pgsql' | set ft=sql
+```vim
+:let b:sql_type_override='pgsql' | set ft=sql
+```
 
 Code between `$pgsql$` or `$$` pairs is treated as PL/pgSQL and highlighted
 accordingly:
@@ -57,12 +64,13 @@ accordingly:
 You may set `g:pgsql_pl` to a list of file types to be used in user-defined
 functions. For example, after setting:
 
-    let g:pgsql_pl = ['python']
+```vim
+let g:pgsql_pl = ['python']
+```
 
 code between `$python$` pairs will be highlighted as Python:
 
 ![PL/Pythonu snippet](https://raw.github.com/lifepillar/Resources/master/pgsql/plpython.png)
-
 
 # Hacking
 
@@ -70,7 +78,7 @@ The syntax file is generated automatically. If you want to hack it, edit
 `src/pgsql.sql`, then execute:
 
 ```sh
-cd src
+cd ./src
 make install
 ```
 
@@ -79,12 +87,10 @@ PostgreSQL instance: `make` will create a database called `vim_pgsql_syntax` to
 extract all the keywords. You may then execute `make distclean` to drop the
 database.
 
-The script has been tested in macOS, but it should work on any *nix system.
-
+The script has been tested in macOS, but it should work on any \*nix system.
 
 # Acknowledgments
 
 This plugin was originally based on code from
 [space::tekk](https://github.com/spacetekk/pgsql.vim) (and completely
 rewritten).
-


### PR DESCRIPTION
- `vim` and `bash` code fences around the code blocks (as per CommonMark, and GFM)
- used `prettier` to format the output with consistent spacing, etc
- add emply `.prettierrc` so that future edits will have the same defaults