### PR TITLE
Fold SQL statements

### DIFF
--- a/src/pgsql.sql
+++ b/src/pgsql.sql
@@ -338,6 +338,9 @@ else
     \ contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlPlpgsqlKeyword,sqlPlpgsqlVariable,sqlPlpgsqlOperator,sqlNumber,sqlIsOperator,sqlString,sqlTodo
 endif
 
+" Folding
+syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold contains=ALL
+
 " PL/<any other language>
 fun! s:add_syntax(s)
   execute 'syn include @PL' . a:s . ' syntax/' . a:s . '.vim'

--- a/syntax/pgsql.vim
+++ b/syntax/pgsql.vim
@@ -1970,6 +1970,9 @@ else
     \ contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlPlpgsqlKeyword,sqlPlpgsqlVariable,sqlPlpgsqlOperator,sqlNumber,sqlIsOperator,sqlString,sqlTodo
 endif
 
+" Folding
+syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold contains=ALL
+
 " PL/<any other language>
 fun! s:add_syntax(s)
   execute 'syn include @PL' . a:s . ' syntax/' . a:s . '.vim'


### PR DESCRIPTION
This is based on the way vim's default [sqloracle.vim](https://github.com/vim/vim/blob/master/runtime/syntax/sqloracle.vim) defines folds.  A fold starts with a keyword like CREATE and ends with a ; at the end of a line.

There might be some regressions, e.g. I think `CREATE OR REPLACE FUNCTION ...` is now getting highlighted incorrectly.

This is a draft PR because I edited the generated .vim instead of src/pgsql.sql.  I just want to know if the approach seems reasonable, or if there's a better way of doing folds, or maybe if you would like a variable check to enable/disable folding in a user's .vimrc?

Closes: #18.