### PR TITLE
Fold functions only

### DIFF
--- a/doc/pgsql.txt
+++ b/doc/pgsql.txt
@@ -80,6 +80,12 @@ By default, text quoted with `$$` is highlighted as PL/pgSQL.
 >
 	let g:pgsql_dollar_strings = 0
 <
+						*'g:pgsql_fold_functions_only'*
+Use this option if you want to fold obly code of stored functions, procedures
+and "do" blocks.
+>
+	let g:pgsql_fold_functions_only = 1
+<
 						*'g:pgsql_pl'*
 						*'b:pgsql_pl'*
 A List of the filetypes that should be highlighted inside the body of

--- a/doc/tags
+++ b/doc/tags
@@ -2,6 +2,7 @@
 'g:pgsql_backslash_quote'	pgsql.txt	/*'g:pgsql_backslash_quote'*
 'g:pgsql_disabled_extensions'	pgsql.txt	/*'g:pgsql_disabled_extensions'*
 'g:pgsql_dollar_strings'	pgsql.txt	/*'g:pgsql_dollar_strings'*
+'g:pgsql_fold_functions_only'	pgsql.txt	/*'g:pgsql_fold_functions_only'*
 'g:pgsql_pl'	pgsql.txt	/*'g:pgsql_pl'*
 pgsql-autocompletion	pgsql.txt	/*pgsql-autocompletion*
 pgsql-contents	pgsql.txt	/*pgsql-contents*

--- a/src/pgsql.sql
+++ b/src/pgsql.sql
@@ -342,23 +342,34 @@ else
     \ contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlPlpgsqlKeyword,sqlPlpgsqlVariable,sqlPlpgsqlOperator,sqlNumber,sqlIsOperator,sqlString,sqlTodo
 endif
 
-" Folding
-if get(g:, 'pgsql_fold_functions_only', 0)
-	syn region sqlFold start=/^\s*\zs\c\%(create\s\+[a-z ]*\%(function\|procedure\)\|do\)\>/ end=/;$/ contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo,plpgsql transparent fold
-else 
-	syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo,plpgsql
-endif
+let s:plgroups = 'plpgsql'
 
 " PL/<any other language>
 fun! s:add_syntax(s)
-  execute 'syn include @PL' . a:s . ' syntax/' . a:s . '.vim'
+  execute 'syn include @PL' .. a:s .. ' syntax/' .. a:s .. '.vim'
   unlet b:current_syntax
-  execute 'syn region pgsqlpl' . a:s . ' matchgroup=sqlString start=+\$' . a:s . '\$+ end=+\$' . a:s . '\$+ keepend contains=@PL' . a:s
+  execute 'syn region pgsqlpl' .. a:s .. ' matchgroup=sqlString start=+\$' .. a:s .. '\$+ end=+\$' .. a:s .. '\$+ keepend contains=@PL' .. a:s
+  let s:plgroups ..= ',pgsqlpl' .. a:s
 endf
 
 for pl in get(b:, 'pgsql_pl', get(g:, 'pgsql_pl', []))
   call s:add_syntax(pl)
 endfor
+
+" Folding
+if get(g:, 'pgsql_fold_functions_only', 0)
+
+    execute "syn region sqlFold start=/^\s*\zs\c\%(create\s\+[a-z ]*\%(function\|procedure\)\|do\)\>/ end=/;$/ transparent fold "
+        \ .. "contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo," .. s:plgroups
+
+else
+
+    execute "syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold "
+      \ .. "contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo," .. s:plgroups
+
+endif
+
+unlet s:plgroups
 
 " Default highlighting
 hi def link sqlCatalog        Constant

--- a/src/pgsql.sql
+++ b/src/pgsql.sql
@@ -359,12 +359,12 @@ endfor
 " Folding
 if get(g:, 'pgsql_fold_functions_only', 0)
 
-    execute "syn region sqlFold start=/^\s*\zs\c\%(create\s\+[a-z ]*\%(function\|procedure\)\|do\)\>/ end=/;$/ transparent fold "
+    execute 'syn region sqlFold start=/^\s*\zs\c\%(create\s\+[a-z ]*\%(function\|procedure\)\|do\)\>/ end=/;$/ transparent fold '
         \ .. "contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo," .. s:plgroups
 
 else
 
-    execute "syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold "
+    execute 'syn region sqlFold start=/^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>/ end=/;$/ transparent fold '
       \ .. "contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo," .. s:plgroups
 
 endif

--- a/src/pgsql.sql
+++ b/src/pgsql.sql
@@ -343,7 +343,11 @@ else
 endif
 
 " Folding
-syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo,plpgsql
+if get(g:, 'pgsql_fold_functions_only', 0)
+	syn region sqlFold start=/^\s*\zs\c\%(create\s\+[a-z ]*\%(function\|procedure\)\|do\)\>/ end=/;$/ contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo,plpgsql transparent fold
+else 
+	syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo,plpgsql
+endif
 
 " PL/<any other language>
 fun! s:add_syntax(s)

--- a/syntax/pgsql.vim
+++ b/syntax/pgsql.vim
@@ -2007,7 +2007,11 @@ else
 endif
 
 " Folding
-syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo,plpgsql
+if get(g:, 'pgsql_fold_functions_only', 0)
+	syn region sqlFold start=/^\s*\zs\c\%(create\s\+[a-z ]*\%(function\|procedure\)\|do\)\>/ end=/;$/ contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo,plpgsql transparent fold
+else 
+	syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo,plpgsql
+endif
 
 " PL/<any other language>
 fun! s:add_syntax(s)

--- a/syntax/pgsql.vim
+++ b/syntax/pgsql.vim
@@ -5,7 +5,7 @@
 " License:      Vim license (see `:help license`)
 
 " Based on PostgreSQL 13.1
-" Automatically generated on 2020-12-30 at 10:21:40
+" Automatically generated on 2021-01-13 at 20:54:21
 
 if exists("b:current_syntax")
   finish
@@ -2006,23 +2006,34 @@ else
     \ contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlPlpgsqlKeyword,sqlPlpgsqlVariable,sqlPlpgsqlOperator,sqlNumber,sqlIsOperator,sqlString,sqlTodo
 endif
 
-" Folding
-if get(g:, 'pgsql_fold_functions_only', 0)
-	syn region sqlFold start=/^\s*\zs\c\%(create\s\+[a-z ]*\%(function\|procedure\)\|do\)\>/ end=/;$/ contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo,plpgsql transparent fold
-else 
-	syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo,plpgsql
-endif
+let s:plgroups = 'plpgsql'
 
 " PL/<any other language>
 fun! s:add_syntax(s)
-  execute 'syn include @PL' . a:s . ' syntax/' . a:s . '.vim'
+  execute 'syn include @PL' .. a:s .. ' syntax/' .. a:s .. '.vim'
   unlet b:current_syntax
-  execute 'syn region pgsqlpl' . a:s . ' matchgroup=sqlString start=+\$' . a:s . '\$+ end=+\$' . a:s . '\$+ keepend contains=@PL' . a:s
+  execute 'syn region pgsqlpl' .. a:s .. ' matchgroup=sqlString start=+\$' .. a:s .. '\$+ end=+\$' .. a:s .. '\$+ keepend contains=@PL' .. a:s
+  let s:plgroups ..= ',pgsqlpl' .. a:s
 endf
 
 for pl in get(b:, 'pgsql_pl', get(g:, 'pgsql_pl', []))
   call s:add_syntax(pl)
 endfor
+
+" Folding
+if get(g:, 'pgsql_fold_functions_only', 0)
+
+    execute "syn region sqlFold start=/^\s*\zs\c\%(create\s\+[a-z ]*\%(function\|procedure\)\|do\)\>/ end=/;$/ transparent fold "
+        \ .. "contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo," .. s:plgroups
+
+else
+
+    execute "syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold "
+      \ .. "contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo," .. s:plgroups
+
+endif
+
+unlet s:plgroups
 
 " Default highlighting
 hi def link sqlCatalog        Constant
@@ -2052,4 +2063,3 @@ hi def link sqlCreateOperatorKeyword sqlKeyword
 hi def link sqlCreateTextSearchKeyword sqlKeyword
 
 let b:current_syntax = "sql"
-

--- a/syntax/pgsql.vim
+++ b/syntax/pgsql.vim
@@ -2023,12 +2023,12 @@ endfor
 " Folding
 if get(g:, 'pgsql_fold_functions_only', 0)
 
-    execute "syn region sqlFold start=/^\s*\zs\c\%(create\s\+[a-z ]*\%(function\|procedure\)\|do\)\>/ end=/;$/ transparent fold "
+    execute 'syn region sqlFold start=/^\s*\zs\c\%(create\s\+[a-z ]*\%(function\|procedure\)\|do\)\>/ end=/;$/ transparent fold '
         \ .. "contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo," .. s:plgroups
 
 else
 
-    execute "syn region sqlFold start='^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>' end=';$' transparent fold "
+    execute 'syn region sqlFold start=/^\s*\zs\c\(create\|update\|alter\|select\|insert\|do\)\>/ end=/;$/ transparent fold '
       \ .. "contains=sqlIsKeyword,sqlIsFunction,sqlComment,sqlIdentifier,sqlNumber,sqlOperator,sqlSpecial,sqlString,sqlTodo," .. s:plgroups
 
 endif


### PR DESCRIPTION
You can use `let g:pgsql_fold_functions_only = 1` to fold only functions, procedures and "do" blocks.