### PR TITLE
Support nested /* */ comments

### DIFF
--- a/src/pgsql.sql
+++ b/src/pgsql.sql
@@ -262,7 +262,7 @@ select vim_format_operators(array(select get_operators()), 'Operator');
 select
 $HERE$
 " Comments
-syn region sqlComment    start="/\*" end="\*/" contains=sqlTodo,@Spell
+syn region sqlComment    start="/\*" end="\*/" contains=sqlTodo,@Spell,sqlComment
 syn match  sqlComment    "#\s.*$"              contains=sqlTodo,@Spell
 syn match  sqlComment    "--.*$"               contains=sqlTodo,@Spell
 

--- a/syntax/pgsql.vim
+++ b/syntax/pgsql.vim
@@ -1999,7 +1999,7 @@ syn match sqlOperator contained "\%(\*>\|->\|<%\|<<\|<=\|<>\|<@\|<\^\|=>\|>=\|>>
 syn match sqlOperator contained "\%(||\|\~\*\|\~=\|\~>\|\~\~\|\#\|%\|&\|\*\|+\|-\|/\|<\|=\|>\|?\|@\|\^\||\|\~\)\ze\%([^!?~#^@<=>%&|*/+-]\|$\)"
 
 " Comments
-syn region sqlComment    start="/\*" end="\*/" contains=sqlTodo,@Spell
+syn region sqlComment    start="/\*" end="\*/" contains=sqlTodo,@Spell,sqlComment
 syn match  sqlComment    "#\s.*$"              contains=sqlTodo,@Spell
 syn match  sqlComment    "--.*$"               contains=sqlTodo,@Spell
 


### PR DESCRIPTION
Thanks for an excellent plugin!

I learned today that PostgreSQL supports [nested C-style comments](https://www.postgresql.org/docs/14/sql-syntax-lexical.html#SQL-SYNTAX-COMMENTS), e.g.

```
/* multiline comment
 * with nesting: /* nested block comment */
 */
```

I'm no expert in vim syntax highlighting, but I searched around and found a few other examples, and this worked for me.